### PR TITLE
Update mako template for INDIGO

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-cloud-info-provider-indigo (0.6.1) trusty; urgency=medium
+
+  * Update mako template to use fields added by java-syncrepo.
+
+ -- Baptiste Grenier <baptiste.grenier@egi.eu>  Wed, 27 Jul 2016 14:17:30 +0200
+
 python-cloud-info-provider-indigo (0.6) trusty; urgency=medium
 
   * First release with support of JSON for INDIGO.

--- a/etc/templates/compute_bdii.indigo
+++ b/etc/templates/compute_bdii.indigo
@@ -4,7 +4,7 @@
   "image_id": "${image_id}",
   ## Docker stuff
   % if 'dockerid' in image:
-  "image_name": "${image["image_name"]}:${image["dockertag"]}",
+  "image_name": "${image["dockername"]}:${image["dockertag"]}",
   "docker_id": "${image["dockerid"]}",
   % else:
   "image_name": "${image["image_name"]}",

--- a/etc/templates/compute_bdii.indigo
+++ b/etc/templates/compute_bdii.indigo
@@ -1,3 +1,4 @@
+<% last_img_index = len(attributes["images"])-1 %>
 % for image_id, image in attributes["images"].iteritems():
 {
   "image_id": "${image_id}",
@@ -7,6 +8,12 @@
   "docker_id": "${image["dockerid"]}",
   % else:
   "image_name": "${image["image_name"]}",
+  % endif
+  % if 'vmcatcher_event_ad_mpuri' in image:
+  "image_marketplace_id": "${image["vmcatcher_event_ad_mpuri"]}",
+  % endif
+  % if 'description' in image:
+  "image_description": "${image["description"]}",
   % endif
   ## Architecture
   % if 'hw_architecture' in image:
@@ -30,20 +37,17 @@
   % endif
   ## OS version
   % if 'version' in image:
-  "version": "${image["version"]}",
+  "version": "${image["version"]}"
   % elif 'dist_version' in image:
-  "version": "${image["dist_version"]}",
+  "version": "${image["dist_version"]}"
   % elif 'vmcatcher_event_hv_version' in image:
-  "version": "${image["vmcatcher_event_hv_version"]}",
+  "version": "${image["vmcatcher_event_hv_version"]}"
   % else:
-  "version": null,
+  "version": null
   % endif
-  ## generic information
-  % if 'vmcatcher_event_ad_mpuri' in image:
-  "image_marketplace_id": "${image["vmcatcher_event_ad_mpuri"]}",
-  % endif
-  % if 'description' in image:
-  "image_description": "${image["description"]}",
-  % endif
+  % if loop.index < last_img_index:
 },
+  % else:
+}
+% endif
 % endfor

--- a/etc/templates/compute_bdii.indigo
+++ b/etc/templates/compute_bdii.indigo
@@ -1,16 +1,49 @@
 % for image_id, image in attributes["images"].iteritems():
 {
-  image_id: "${image_id}"
-  % for name, value in image.iteritems():
-  % if name == "vmcatcher_event_hv_version":
-  image_version: "${value}",
-  % elif name == "vmcatcher_event_ad_mpuri":
-  image_marketplace_id: "${value}",
-  % elif name == "description":
-  image_description: "${value}"
+  "image_id": "${image_id}",
+  ## Docker stuff
+  % if 'dockerid' in image:
+  "image_name": "${image["image_name"]}:${image["dockertag"]}",
+  "docker_id": "${image["dockerid"]}",
   % else:
-  ${name}: "${value}",
+  "image_name": "${image["image_name"]}",
   % endif
-  % endfor
+  ## Architecture
+  % if 'hw_architecture' in image:
+  "architecture": "${image["hw_architecture"]}",
+  % elif 'architecture' in image:
+  "architecture": "${image["architecture"]}",
+  % else:
+  "architecture": null,
+  % endif
+  ## OS type
+  % if 'os' in image:
+  "type:" "${image["os"]}",
+  % else:
+  "type": null,
+  % endif
+  ## OS distribution
+  % if 'distribution' in image:
+  "distribution": "${image["distribution"]}",
+  % else:
+  "distribution": null,
+  % endif
+  ## OS version
+  % if 'version' in image:
+  "version": "${image["version"]}",
+  % elif 'dist_version' in image:
+  "version": "${image["dist_version"]}",
+  % elif 'vmcatcher_event_hv_version' in image:
+  "version": "${image["vmcatcher_event_hv_version"]}",
+  % else:
+  "version": null,
+  % endif
+  ## generic information
+  % if 'vmcatcher_event_ad_mpuri' in image:
+  "image_marketplace_id": "${image["vmcatcher_event_ad_mpuri"]}",
+  % endif
+  % if 'description' in image:
+  "image_description": "${image["description"]}",
+  % endif
 },
 % endfor

--- a/rpm/cloud-info-provider-indigo.spec
+++ b/rpm/cloud-info-provider-indigo.spec
@@ -6,7 +6,7 @@
 
 Summary: Information provider for Cloud Compute and Cloud Storage services for INDIGO
 Name: cloud-info-provider-indigo
-Version: 0.6.0
+Version: 0.6.1
 Release: 1%{?dist}
 Group: Applications/Internet
 License: ASL 2.0
@@ -48,6 +48,8 @@ rm -rf $RPM_BUILD_ROOT
 %config /etc/cloud-info-provider-indigo/
 
 %changelog
+* Wed Jul 27 2016 Baptiste Grenier <baptiste.grenier@egi.eu> - 0.6.1-{%release}
+- Update mako template to use fields added by java-syncrepo.
 * Wed Jul 6 2016 Baptiste Grenier <baptiste.grenier@egi.eu> - 0.6.0-{%release}
 - First release
 - Based on cloud-info-provider.spec from EGI-FCTF/cloud-bdii-provider

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = cloud_provider_indigo
 summary = INDIGO Cloud info provider
-version = 0.6
+version = 0.6.1
 description-file =
     README.md
 author = Alvaro Lopez Garcia


### PR DESCRIPTION
Update mako template for INDIGO to use latest fields added by java-syncrepos.
Bump version to 0.6.1.
