### PR TITLE
Version 0.9.3: hide verbose output of some python dependencies.

### DIFF
--- a/cloud_info/providers/openstack.py
+++ b/cloud_info/providers/openstack.py
@@ -17,6 +17,8 @@ class OpenStackProvider(providers.BaseProvider):
 
         # Remove info log messages from output
         logging.getLogger('requests').setLevel(logging.WARNING)
+        logging.getLogger('urllib3').setLevel(logging.WARNING)
+        logging.getLogger('novaclient.client').setLevel(logging.WARNING)
 
         (os_username, os_password, os_tenant_name, os_auth_url,
             os_api_version, cacert, insecure, legacy_occi_os) = (

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-cloud-info-provider-indigo (0.9.3) trusty; urgency=medium
+
+  * Hide verbose output for some dependencies (urllib3 and novaclient).
+
+ -- Baptiste Grenier <baptiste.grenier@egi.eu>  Tue, 13 Sep 2016 18:40:42 +0200
+
 python-cloud-info-provider-indigo (0.9.2) trusty; urgency=medium
 
   * Revert to OpenStack Identity API V2.0 to be compatible with Liberty.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Mako
 PyYAML
 six
 requests
+pbr

--- a/rpm/cloud-info-provider-indigo.spec
+++ b/rpm/cloud-info-provider-indigo.spec
@@ -6,7 +6,7 @@
 
 Summary: Information provider for Cloud Compute and Cloud Storage services for INDIGO
 Name: cloud-info-provider-indigo
-Version: 0.9.2
+Version: 0.9.3
 Release: 1%{?dist}
 Group: Applications/Internet
 License: ASL 2.0
@@ -51,6 +51,8 @@ rm -rf $RPM_BUILD_ROOT
 %config /etc/cloud-info-provider-indigo/
 
 %changelog
+* Fri Sep 13 2016 Baptiste Grenier <baptiste.grenier@egi.eu> - 0.9.3-{%release}
+- Hide verbose output for some dependencies (urllib3 and novaclient).
 * Fri Aug 19 2016 Baptiste Grenier <baptiste.grenier@egi.eu> - 0.9.2-{%release}
 - Revert to OpenStack Identity API V2.0 to be compatible with Liberty.
 * Tue Aug 16 2016 Baptiste Grenier <baptiste.grenier@egi.eu> - 0.9.1-{%release}


### PR DESCRIPTION
Hide verbose output of urllib3 and novaclient (affecting only certain platform/versions.)
